### PR TITLE
🧮 fix calculation

### DIFF
--- a/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/ActionsEntryDataProcessor.cs
+++ b/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/ActionsEntryDataProcessor.cs
@@ -10,6 +10,6 @@ public class ActionsEntryDataProcessor : IReportEntryDataProcessor
         enterprise.ActionsConsumptionPerOwner[item.Owner].MinutesPerSku.TryAdd(item.SKU, 0);
         enterprise.ActionsConsumptionPerOwner[item.Owner].MinutesPerSku[item.SKU] += item.Quantity;
         enterprise.ActionsConsumptionPerOwner[item.Owner].PricePerRepository.TryAdd(item.RepositorySlug, 0);
-        enterprise.ActionsConsumptionPerOwner[item.Owner].PricePerRepository[item.RepositorySlug] += item.Quantity * item.Multiplier * item.PricePerUnit;
+        enterprise.ActionsConsumptionPerOwner[item.Owner].PricePerRepository[item.RepositorySlug] += item.Quantity * item.PricePerUnit;
     }
 }

--- a/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/CopilotEntryDataProcessor.cs
+++ b/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/CopilotEntryDataProcessor.cs
@@ -7,7 +7,7 @@ public class CopilotEntryDataProcessor : IReportEntryDataProcessor
         if (item.Product is not Product.Copilot) return;
 
         var owner = item.Owner;
-        var price = item.PricePerUnit * item.Quantity * item.Multiplier;
+        var price = item.PricePerUnit * item.Quantity;
 
         enterprise.CopilotConsumptionPerOwner.TryAdd(owner, new());
 

--- a/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/MeteredBillingReportItemParser.cs
+++ b/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/MeteredBillingReportItemParser.cs
@@ -9,7 +9,7 @@ public class MeteredBillingReportItemParser : IReportItemParser<MeteredBillingRe
         return new MeteredBillingReportItem
         {
             Date = DateTime.Parse(values[0]),
-            Product = Enum.Parse<Product>(values[1]),
+            Product = SafeParse(values[1]),
             SKU = values[2],
             Quantity = decimal.Parse(values[3], CultureInfo.InvariantCulture),
             UnitType = values[4],
@@ -21,5 +21,11 @@ public class MeteredBillingReportItemParser : IReportItemParser<MeteredBillingRe
             ActionsWorkflow = values[10],
             Notes = values[11]
         };
+        
+        static Product SafeParse(string value)
+        {
+            var sanitizedValue = value.Replace(" ", string.Empty);
+            return Enum.TryParse<Product>(sanitizedValue, out var product) ? product : Product.Unknown;
+        }
     }
 }

--- a/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/Product.cs
+++ b/src/ActionsUsageAnalyser.Domain/MeteredBillingReport/Product.cs
@@ -6,4 +6,5 @@ public enum Product
     Actions,
     SharedStorage,
     Copilot,
+    Packages
 }

--- a/tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/ActionsEntryDataProcessorTests.cs
+++ b/tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/ActionsEntryDataProcessorTests.cs
@@ -97,13 +97,13 @@ public class ActionsEntryDataProcessorTests
         foreach (var sku in items.GroupBy(i => i.SKU))
         {
             enterprise.ActionsConsumptionPerOwner["owner"].MinutesPerSku.ShouldContainKey(sku.Key);
-            enterprise.ActionsConsumptionPerOwner["owner"].MinutesPerSku[sku.Key].ShouldBe(sku.Sum(i => i.Quantity));    
+            enterprise.ActionsConsumptionPerOwner["owner"].MinutesPerSku[sku.Key].ShouldBe(sku.Sum(i => i.Quantity));
         }
 
         foreach (var group in items.GroupBy(i => i.RepositorySlug))
         {
             enterprise.ActionsConsumptionPerOwner["owner"].PricePerRepository.ShouldContainKey(group.Key);
-            enterprise.ActionsConsumptionPerOwner["owner"].PricePerRepository[group.Key].ShouldBe(group.Sum(i => i.Quantity * i.Multiplier * i.PricePerUnit));
+            enterprise.ActionsConsumptionPerOwner["owner"].PricePerRepository[group.Key].ShouldBe(group.Sum(i => i.Quantity * i.PricePerUnit));
         }
     }
 }

--- a/tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/CopilotEntryDataProcessorTests.cs
+++ b/tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/CopilotEntryDataProcessorTests.cs
@@ -75,7 +75,7 @@ public class CopilotEntryDataProcessorTests
                 Owner = "owner",
                 SKU = "Copilot for Business",
                 Quantity = 0.23m,
-                Multiplier = 1,
+                Multiplier = 2,
                 PricePerUnit = 19.0m
             }
         };
@@ -87,7 +87,7 @@ public class CopilotEntryDataProcessorTests
         
         enterprise.ShouldSatisfyAllConditions(
             () => enterprise.CopilotConsumptionPerOwner.ShouldContainKey(items[0].Owner),
-            () => enterprise.CopilotConsumptionPerOwner[items[0].Owner].AccumulatedPrise.ShouldBe(items.Sum(i => i.Quantity * i.Multiplier * i.PricePerUnit))
+            () => enterprise.CopilotConsumptionPerOwner[items[0].Owner].AccumulatedPrise.ShouldBe(items.Sum(i => i.Quantity * i.PricePerUnit))
         );
     }
 }

--- a/tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/MeteredBillingReportItemParserTests.cs
+++ b/tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/MeteredBillingReportItemParserTests.cs
@@ -86,4 +86,20 @@ public class MeteredBillingReportItemParserTests
             () => actualItem.Notes.ShouldBe(expectedItem.Notes)
         );
     }
+    
+    [Theory]
+    [InlineData("Packages", Product.Packages)]
+    [InlineData("Actions", Product.Actions)]
+    [InlineData("Copilot", Product.Copilot)]
+    [InlineData("Shared Storage", Product.SharedStorage)]
+    [InlineData("zzzz", Product.Unknown)]
+    public void ProductType_Converted_As_Expected(string productType, Product expectedProduct)
+    {
+        var csvLine = $"2023-08-02,{productType},Copilot for Business,0.1613,user-month,19.0,1.0,org-name-three,,,,";
+        var parser = new MeteredBillingReportItemParser();
+        
+        var actualItem = parser.Parse(csvLine.Split(","));
+        
+        actualItem.Product.ShouldBe(expectedProduct);
+    }
 }


### PR DESCRIPTION
Copilot generated summary: 

This pull request includes a variety of changes to fix issues and improve functionality in the `ActionsUsageAnalyser` codebase. The most important changes include correcting the calculation of copilot consumption price per owner in the `CopilotEntryDataProcessor` class, adding a new enum value to the `Product` enum, and correcting the calculation of price per repository for actions consumption per owner in the `ActionsEntryDataProcessor` class.

Testing improvements:

* <a href="diffhunk://#diff-6c396edf4e1524f7f3a137d11bed90e95d828add908a734d2cc6db16e7415e88R89-R104">`tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/MeteredBillingReportItemParserTests.cs`</a>: Added a new test method to test the conversion of product types from string to enum.
* <a href="diffhunk://#diff-01b2f686ab5316d9527d863b2a747bf88fa474f066f3c4dc2c931737cf752eddL90-R90">`tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/CopilotEntryDataProcessorTests.cs`</a>: The copilot consumption price calculation was corrected in the `ProcessForEnterprise_WhenCalledForMultipleEntries_Should_AggregateIn` test method and the `Multiplier` property of a `MeteredBillingReportItem` object was changed for testing purposes. <a href="diffhunk://#diff-01b2f686ab5316d9527d863b2a747bf88fa474f066f3c4dc2c931737cf752eddL90-R90">[1]</a> <a href="diffhunk://#diff-01b2f686ab5316d9527d863b2a747bf88fa474f066f3c4dc2c931737cf752eddL78-R78">[2]</a>
* <a href="diffhunk://#diff-12141aa47de97e6f09038cd7356d3520dfec50275c3ebe258db266bee6e16fdcL106-R106">`tests/ActionsUsageAnalyser.Domain.Tests/MeteredBillingReport/ActionsEntryDataProcessorTests.cs`</a>: The `ProcessForEnterprise_WhenCalledMultipleTimes_AggregatesData` test method was corrected to remove the `Multiplier` property from the calculation of price per repository for actions consumption per owner.

Main interface changes:

* `src/ActionsUsageAnalyser.Domain/MeteredBillingReport/CopilotEntryDataProcessor.cs`: The calculation of copilot consumption price per owner was corrected in the `ProcessForEnterprise` method of `CopilotEntryDataProcessor` class by removing the `Multiplier` property from the calculation. (Fb2c3d4eL5R5)
* `src/ActionsUsageAnalyser.Domain/MeteredBillingReport/Product.cs`: Added a new enum value `Packages` to the `Product` enum. (F1234567L8R8)
* <a href="diffhunk://#diff-d0b7ff97a5a0a0cc4fe890d14626ce869c577afd4fb1ebd12868b86565071b89L13-R13">`src/ActionsUsageAnalyser.Domain/MeteredBillingReport/ActionsEntryDataProcessor.cs`</a>: The calculation of price per repository for actions consumption per owner was corrected in the `ProcessForEnterprise` method of `ActionsEntryDataProcessor.cs` by removing the `Multiplier` property.

Utility improvements:

* <a href="diffhunk://#diff-413df7099fa7af1380dd0b2a989351e6b20cb0a9dfe35870d6d03f1227a6e821L12-R12">`src/ActionsUsageAnalyser.Domain/MeteredBillingReport/MeteredBillingReportItemParser.cs`</a>: A new static method `SafeParse` was added to the `MeteredBillingReportItemParser` class to safely parse the `Product` enum value from a string by removing any spaces before parsing. <a href="diffhunk://#diff-413df7099fa7af1380dd0b2a989351e6b20cb0a9dfe35870d6d03f1227a6e821L12-R12">[1]</a> <a href="diffhunk://#diff-413df7099fa7af1380dd0b2a989351e6b20cb0a9dfe35870d6d03f1227a6e821R24-R29">[2]</a> 