### PR TITLE
Add support for HTML output in OutputProvider

### DIFF
--- a/src/ActionsUsageAnalyzer.Infrastructure/HtmlOutputWriter.cs
+++ b/src/ActionsUsageAnalyzer.Infrastructure/HtmlOutputWriter.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using ActionsUsageAnalyser.Domain;
+
+
+
+namespace ActionsUsageAnalyzer.Infrastructure;
+
+    public class HtmlOutputWriter : IOutputWriter
+    {
+        private readonly TextWriter writer;
+
+        public HtmlOutputWriter(string filePath)
+        {
+            writer = File.CreateText(filePath);
+            writer.WriteLine("<html>");
+            writer.WriteLine("<body>");
+        }
+
+        public void WriteLine(string line)
+        {
+            writer.WriteLine(line);
+        }
+
+        public void WriteTitle(int level, string line)
+        {
+            writer.WriteLine($"<h{level}>{line}</h{level}>");
+        }
+
+        public void BeginTable(params string[] headers)
+        {
+            writer.WriteLine("<table>");
+            writer.WriteLine("<tr>");
+            foreach (var header in headers)
+            {
+                writer.WriteLine($"<th>{header}</th>");
+            }
+            writer.WriteLine("</tr>");
+        }
+
+        public void WriteTableRow(params string[] columns)
+        {
+            writer.WriteLine("<tr>");
+            foreach (var column in columns)
+            {
+                writer.WriteLine($"<td>{column}</td>");
+            }
+            writer.WriteLine("</tr>");
+        }
+
+        public void EndTable()
+        {
+            writer.WriteLine("</table>");
+        }
+
+        public void Dispose()
+        {
+            writer.WriteLine("</body>");
+            writer.WriteLine("</html>");
+            writer.Close();
+            writer.Dispose();
+        }
+    }

--- a/src/ActionsUsageAnalyzer.Infrastructure/HtmlOutputWriter.cs
+++ b/src/ActionsUsageAnalyzer.Infrastructure/HtmlOutputWriter.cs
@@ -1,10 +1,8 @@
 using System.IO;
 using ActionsUsageAnalyser.Domain;
 
-
-
-namespace ActionsUsageAnalyzer.Infrastructure;
-
+namespace ActionsUsageAnalyzer.Infrastructure
+{
     public class HtmlOutputWriter : IOutputWriter
     {
         private readonly TextWriter writer;
@@ -13,6 +11,12 @@ namespace ActionsUsageAnalyzer.Infrastructure;
         {
             writer = File.CreateText(filePath);
             writer.WriteLine("<html>");
+            writer.WriteLine("<head>");
+            writer.WriteLine("<style>");
+            writer.WriteLine("body { background-color: red; }");
+            writer.WriteLine("h1, h2, h3, h4, h5, h6 { color: green; }");
+            writer.WriteLine("</style>");
+            writer.WriteLine("</head>");
             writer.WriteLine("<body>");
         }
 
@@ -60,3 +64,4 @@ namespace ActionsUsageAnalyzer.Infrastructure;
             writer.Dispose();
         }
     }
+}

--- a/src/ActionsUsageAnalyzer.Infrastructure/OutputProvider.cs
+++ b/src/ActionsUsageAnalyzer.Infrastructure/OutputProvider.cs
@@ -17,6 +17,13 @@ public class OutputProvider : IOutputProvider
         {
             return new ConsoleOutputWriter();
         }
-        return new MarkdownDocumentOutputWriter(filePath);
+        else if (filePath.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+        {
+            return new HtmlOutputWriter(filePath);
+        }
+        else
+        {
+            return new MarkdownDocumentOutputWriter(filePath);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces changes to support generating HTML output in the application. It includes the addition of a new `HtmlOutputWriter` class that implements the `IOutputWriter` interface and provides functionality for writing output in HTML format. Additionally, a condition is added in the `GetOutputWriter()` method to return an instance of `HtmlOutputWriter` when the `filePath` ends with ".html".

Main changes:

* <a href="diffhunk://#diff-63c7dce035ec1b1e11136ceafa8701e8f95147b2e475608803b363aa25eb9d7bR1-R62">`src/ActionsUsageAnalyzer.Infrastructure/HtmlOutputWriter.cs`</a>: Added a new `HtmlOutputWriter` class that implements the `IOutputWriter` interface and provides functionality for writing output in HTML format.
* <a href="diffhunk://#diff-7c2f58900404f49e52371c068150ee08f9b59700f03100fa7d6755debc87578fR20-R29">`src/ActionsUsageAnalyzer.Infrastructure/OutputProvider.cs`</a>: Added a condition in the `GetOutputWriter()` method to return an instance of `HtmlOutputWriter` when the `filePath` ends with ".html".