### PR TITLE
Fix #6: Add HTML format option for report summary

### DIFF
--- a/src/ActionsUsageAnalyzer.Infrastructure/HtmlDocumentOutputWriter.cs
+++ b/src/ActionsUsageAnalyzer.Infrastructure/HtmlDocumentOutputWriter.cs
@@ -1,0 +1,70 @@
+using ActionsUsageAnalyser.Domain;
+using System.IO;
+using System.Text;
+
+namespace ActionsUsageAnalyzer.Infrastructure;
+
+public class HtmlDocumentOutputWriter : IOutputWriter
+{
+    private readonly TextWriter writer;
+    private readonly StringBuilder tableBuilder;
+
+    public HtmlDocumentOutputWriter(string filePath)
+    {
+        writer = File.CreateText(filePath);
+        tableBuilder = new StringBuilder();
+    }
+
+    public void WriteLine(string line)
+    {
+        writer.WriteLine($"<p>{line}</p>");
+    }
+
+    public void WriteTitle(int level, string line)
+    {
+        writer.WriteLine($"<h{level}>{line}</h{level}>");
+    }
+
+    public void BeginTable(params string[] headers)
+    {
+        tableBuilder.Clear();
+        tableBuilder.AppendLine("<table>");
+        tableBuilder.AppendLine("<thead>");
+        tableBuilder.AppendLine("<tr>");
+        foreach (var header in headers)
+        {
+            tableBuilder.AppendLine($"<th>{header}</th>");
+        }
+        tableBuilder.AppendLine("</tr>");
+        tableBuilder.AppendLine("</thead>");
+        tableBuilder.AppendLine("<tbody>");
+    }
+
+    public void WriteTableRow(params string[] columns)
+    {
+        tableBuilder.AppendLine("<tr>");
+        foreach (var column in columns)
+        {
+            tableBuilder.AppendLine($"<td>{column}</td>");
+        }
+        tableBuilder.AppendLine("</tr>");
+    }
+
+    public void EndTable()
+    {
+        tableBuilder.AppendLine("</tbody>");
+        tableBuilder.AppendLine("</table>");
+        writer.WriteLine(tableBuilder.ToString());
+    }
+
+    public void Dispose()
+    {
+        // write the HTML template with the report summary as the content
+        var template = File.ReadAllText("HtmlTemplate.html");
+        var content = writer.ToString();
+        var html = template.Replace("{{content}}", content);
+        writer.Write(html);
+        writer.Close();
+        writer.Dispose();
+    }
+}

--- a/src/ActionsUsageAnalyzer.Infrastructure/HtmlTemplate.html
+++ b/src/ActionsUsageAnalyzer.Infrastructure/HtmlTemplate.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Report Summary</title>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th, td {
+            border: 1px solid black;
+            padding: 10px;
+            text-align: left;
+        }
+
+        h1, h2, h3, h4 {
+            margin: 10px 0;
+        }
+
+        p {
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    {{content}}
+</body>
+</html>

--- a/src/ActionsUsageAnalyzer.Infrastructure/OutputProvider.cs
+++ b/src/ActionsUsageAnalyzer.Infrastructure/OutputProvider.cs
@@ -17,6 +17,11 @@ public class OutputProvider : IOutputProvider
         {
             return new ConsoleOutputWriter();
         }
+        // return a HtmlDocumentOutputWriter if the output file path has a .html extension
+        if (Path.GetExtension(filePath) == ".html")
+        {
+            return new HtmlDocumentOutputWriter(filePath);
+        }
         return new MarkdownDocumentOutputWriter(filePath);
     }
 }

--- a/tests/ActionsUsageAnalyser.Domain.Tests/HtmlDocumentOutputWriterTests.cs
+++ b/tests/ActionsUsageAnalyser.Domain.Tests/HtmlDocumentOutputWriterTests.cs
@@ -1,0 +1,54 @@
+using ActionsUsageAnalyser.Domain;
+using ActionsUsageAnalyzer.Infrastructure;
+using Xunit;
+
+namespace ActionsUsageAnalyser.Domain.Tests;
+
+public class HtmlDocumentOutputWriterTests
+{
+    [Fact]
+    public void WriteReportSummary_ShouldGenerateHtmlDocument()
+    {
+        // arrange
+        var filePath = "test.html";
+        var expectedHtml = File.ReadAllText("HtmlTemplate.html");
+        var outputWriter = new HtmlDocumentOutputWriter(filePath);
+
+        // act
+        WriteReportSummary(outputWriter);
+        outputWriter.Dispose();
+
+        // assert
+        var actualHtml = File.ReadAllText(filePath);
+        Assert.Equal(expectedHtml, actualHtml);
+    }
+
+    private void WriteReportSummary(IOutputWriter outputWriter)
+    {
+        // write some sample report summary
+        outputWriter.WriteTitle(1, "Report Summary");
+        outputWriter.WriteLine("This is a sample report summary.");
+        outputWriter.WriteTitle(2, "Actions SKUs for this enterprise");
+        outputWriter.BeginTable("SKU", "Price per minute", "Multiplier");
+        outputWriter.WriteTableRow("actions-minutes-1000", "$0.08", "1.0");
+        outputWriter.WriteTableRow("actions-minutes-5000", "$0.08", "0.8");
+        outputWriter.WriteTableRow("actions-minutes-10000", "$0.08", "0.7");
+        outputWriter.EndTable();
+        outputWriter.WriteLine("Total number of organizations: 3");
+        outputWriter.WriteTitle(2, "Actions consumption per organization");
+        outputWriter.WriteTitle(3, "owner-1");
+        outputWriter.WriteTitle(4, "Consumption per SKU");
+        outputWriter.BeginTable("SKU", "Minutes", "Total price");
+        outputWriter.WriteTableRow("actions-minutes-1000", "500", "$40.00");
+        outputWriter.WriteTableRow("actions-minutes-5000", "1000", "$64.00");
+        outputWriter.EndTable();
+        outputWriter.WriteLine("Total cost for this organization: $104.00");
+        outputWriter.WriteTitle(4, "Top 3 repositories by consumption");
+        outputWriter.BeginTable("Repository", "Total price");
+        outputWriter.WriteTableRow("repo-1", "$50.00");
+        outputWriter.WriteTableRow("repo-2", "$30.00");
+        outputWriter.WriteTableRow("repo-3", "$24.00");
+        outputWriter.EndTable();
+        // write more report summary as needed
+    }
+}

--- a/tests/ActionsUsageAnalyser.Domain.Tests/HtmlTemplate.html
+++ b/tests/ActionsUsageAnalyser.Domain.Tests/HtmlTemplate.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Report Summary</title>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th, td {
+            border: 1px solid black;
+            padding: 10px;
+            text-align: left;
+        }
+
+        h1, h2, h3, h4 {
+            margin: 10px 0;
+        }
+
+        p {
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>Report Summary</h1>
+    <p>This is a sample report summary.</p>
+    <h2>Actions SKUs for this enterprise</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>SKU</th>
+                <th>Price per minute</th>
+                <th>Multiplier</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>actions-minutes-1000</td>
+                <td>$0.08</td>
+                <td>1.0</td>
+            </tr>
+            <tr>
+                <td>actions-minutes-5000</td>
+                <td>$0.08</td>
+                <td>0.8</td>
+            </tr>
+            <tr>
+                <td>actions-minutes-10000</td>
+                <td>$0.08</td>
+                <td>0.7</td>
+            </tr>
+        </tbody>
+    </table>
+    <p>Total number of organizations: 3</p>
+    <h2>Actions consumption per organization</h2>
+    <h3>owner-1</h3>
+    <h4>Consumption per SKU</h4>
+    <table>
+        <thead>
+            <tr>
+                <th>SKU</th>
+                <th>Minutes</th>
+                <th>Total price</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>actions-minutes-1000</td>
+                <td>500</td>
+                <td>$40.00</td>
+            </tr>
+            <tr>
+                <td>actions-minutes-5000</td>
+                <td>1000</td>
+                <td>$64.00</td>
+            </tr>
+        </tbody>
+    </table>
+    <p>Total cost for this organization: $104.00</p>
+    <h4>Top 3 repositories by consumption</h4>
+    <table>
+        <thead>
+            <tr>
+                <th>Repository</th>
+                <th>Total price</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>repo-1</td>
+                <td>$50.00</td>
+            </tr>
+            <tr>
+                <td>repo-2</td>
+                <td>$30.00</td>
+            </tr>
+            <tr>
+                <td>repo-3</td>
+                <td>$24.00</td>
+            </tr>
+        </tbody>
+    </table>
+    <!-- more report summary as needed -->
+</body>
+</html>


### PR DESCRIPTION
Fixes #6

Add HTML format option for report summary

This PR was created with Copilot Workspace (v0.6). For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gh/asizikov/github-metered-billing-report-analyzer/issues/6?shareId=ab2c7457-71d5-43ac-8a5d-ef95332d5ab1).